### PR TITLE
Update documentation to use consistent protocol for analog interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ ADC data can be streamed from any of the nodes by sending a `istart` command and
 analoginterface = "UASP2DAQ"        # use UASP2 protocol
 port = 9819                         # with control port 9819
 
+[output]
+analoginterface = "UASP2DAQ"        # use UASP2 protocol
+
 [bb]
 fc = 24000                          # carrier frequency of 24 kHz
 ```


### PR DESCRIPTION
This PR updates the documentation by adding `UASP2DAQ` to `output.analoginterface` in `modem.toml`, ensuring that both input and output analog interfaces use the same protocol.