### PR TITLE
Performance improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,18 @@
 name = "VirtualAcousticOcean"
 uuid = "629e117c-1786-4222-ab4a-1acab234d923"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
-version = "0.6.1"
+version = "0.7.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Memoization = "6fafb56a-5788-4b4e-91ca-c0cea6611c73"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 UnderwaterAcoustics = "0efb1f7a-1ce7-46d2-9f48-546a4c8fbb99"
 
 [compat]
 Base64 = "1"
 JSON = "0.21"
-UnderwaterAcoustics = "0.4"
+Memoization = "0.2.2"
+UnderwaterAcoustics = "0.7.2"
 julia = "1.9"

--- a/examples/2-node-network.jl
+++ b/examples/2-node-network.jl
@@ -1,15 +1,15 @@
 using VirtualAcousticOcean
 using UnderwaterAcoustics
+using Sockets
 
-env = UnderwaterEnvironment(seabed=SandyClay, bathymetry=40.0)
+env = UnderwaterEnvironment(
+  bathymetry = 40.0,
+  seabed = SandyClay
+)
 pm = PekerisRayTracer(env)
 sim = Simulation(pm, 24000.0)
 addnode!(sim, (0.0, 0.0, -10.0), UASP2, 9809)
 addnode!(sim, (1000.0, 0.0, -5.0), UASP2, 9819)
 run(sim)
 
-while true
-  sleep(10)
-end
-
-#close(sim)
+wait()


### PR DESCRIPTION
Fixes #4 

VAO suffered from poor TX performance on weak machines. This PR adds several performance fixes:

- A performance bug in `DSP.jl` that causes filtering of complex signals to be very slow. `UnderwaterAcoustics.jl` `v0.7.2` improves performance by avoiding `DSP.jl` and dispatching complex filtering to `SignalAnalysis.jl`. This PR updates compat bounds in VAO to force `UnderwaterAcoustics.jl` `v0.7.2`.
- Adds multi-threading to keep VAO responsive during TX.
- Adds caching for static simulations (`mobility=false`, default) to avoid having to recompute the acoustic propagation for each TX.
