### PR TITLE
Add support for replay channels

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VirtualAcousticOcean"
 uuid = "629e117c-1786-4222-ab4a-1acab234d923"
 authors = ["Mandar Chitre <mandar@nus.edu.sg>"]
-version = "0.7.0"
+version = "0.8.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ env = UnderwaterEnvironment(
 pm = PekerisRayTracer(env)            # Pekeris ray model
 ```
 
+Alternatively, we also now support channel-replay based simulations using [recorded underwater channels](https://org-arl.github.io/UnderwaterAcoustics.jl/replay.html). To setup, a simulation using one of those, we create `pm` from the recorded channel (say `red.mat`):
+```julia
+using VirtualAcousticOcean
+
+pm = ReplayChannelModel("red.mat")
+```
+
 We then define a simulation using that environment, adding acoustic nodes to it:
 ```julia
 using VirtualAcousticOcean

--- a/src/sim.jl
+++ b/src/sim.jl
@@ -57,7 +57,7 @@ Create a replay channel model from a `.mat` file containing a baseband replay
 channel.
 
 Supported keyword arguments:
-- `sounspeed`: speed of sound (m/s, default: 1538.9)
+- `soundspeed`: speed of sound (m/s, default: 1538.9)
 - `spreading`: path loss exponent (default: 2, spherical spreading)
 - `scaling`: scale factor (default: 1, see below)
 - `rxs`: indices of receive channels to use (default: 1)


### PR DESCRIPTION
Adds support for VAO simulations using [replay channels](https://org-arl.github.io/UnderwaterAcoustics.jl/replay.html). To set up a replay channel based simulation:
```julia
using VirtualAcousticOcean

pm = ReplayChannelModel("red.mat")
sim = Simulation(pm, 24000.0)
addnode!(sim, (0.0, 0.0, -10.0), UASP2, 9809)
addnode!(sim, (1000.0, 0.0, -10.0), UASP2, 9819)
run(sim)
```

Important things to note:
- The frequency band of operation must be within the frequency band probed by the replay channel.
- By default, only the first channel of the replay channel is loaded. You can change the channel(s) by a keyword arguments `rxs` (e.g. `rxs=2` will choose second channel, `rxs=2:4` will choose channels 2 to 4).
- Multichannel simulations are computationally more expensive and take more memory to store the replay channel. Make sure you have plenty of RAM and a powerful machine if you intend to use many channels.
- Replay based channels only support single transmitter, but multichannel receivers can be used (provided the replay channel was recorded using multiple channels). If you use a multichannel receiver, you should place the receivers hydrophones with the same spacing as what was used to record the channel to ensure that array processing works as expected.
- Although multiple nodes are supported in replay channels, all transmissions will use the exact same channel between pairs of nodes. Each transmission randomly picks a start time in the recorded channel.
- By default, we upsample the recorded channels to the sampling rate of the delay axis. This speeds up simulation at the expense of memory storage. This can be turned off using a keyword argument `upsample=false`. If you turn this off, less memory will be used, but each transmission will take longer. If the time taken to compute a transmission is more than the propagation delay, the transmission will be missed (you will be warned).
